### PR TITLE
Android App Version 12 Crash Resolved

### DIFF
--- a/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
+++ b/android/src/main/java/com/tanguyantoine/react/MusicControlNotification.java
@@ -184,7 +184,16 @@ public class MusicControlNotification {
         Intent intent = new Intent(MEDIA_BUTTON);
         intent.putExtra(Intent.EXTRA_KEY_EVENT, new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
         intent.putExtra(PACKAGE_NAME, packageName);
-        PendingIntent i = PendingIntent.getBroadcast(context, keyCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        
+        
+         int pendingFlags;
+        if (Build.VERSION.SDK_INT >= 23) {
+            pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+        } else {
+            pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        }
+        PendingIntent i = PendingIntent.getBroadcast(context, keyCode, intent,pendingFlags);
+  
 
         return new NotificationCompat.Action(icon, title, i);
     }


### PR DESCRIPTION
Issue Resolved. Added a check for sdk versions above 23 which support FLAG_IMMUTABLE and FLAG_MUTABLE. 

#### What's this PR does?
This prevents the app from crashing on android 12 , SDK 31 And above

#### Which issue(s) is it related to?

java.lang.IllegalArgumentException: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.

#### How to test:
Test on android 12.
